### PR TITLE
eprint protoc args & stderr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build and Check
 
-on: push
+on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always

--- a/grpc-build/src/lib.rs
+++ b/grpc-build/src/lib.rs
@@ -79,9 +79,17 @@ impl Builder {
             cmd.arg(proto);
         }
 
-        cmd.output().context(
+        eprintln!("Running {cmd:?}");
+
+        let out = cmd.output().context(
             "failed to invoke protoc (hint: https://docs.rs/prost-build/#sourcing-protoc)",
         )?;
+
+        eprintln!(
+            "---protoc stderr---\n{}\n------",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION
protoc can exit `0` but not actually work. This PR prints protoc args & stderr output so that this will appear if the build fails.