### PR TITLE
Add default module name

### DIFF
--- a/grpc-build/src/builder.rs
+++ b/grpc-build/src/builder.rs
@@ -49,6 +49,7 @@ impl Builder {
         self
     }
 
+    /// Configures what filename protobufs with no package definition are written to.
     pub fn default_module_name(mut self, name: impl AsRef<str>) -> Self {
         self.default_module_name = Some(name.as_ref().to_string());
         self

--- a/grpc-build/src/builder.rs
+++ b/grpc-build/src/builder.rs
@@ -10,6 +10,7 @@ pub struct Builder {
     pub(crate) protoc_args: Vec<OsString>,
     pub(crate) out_dir: Option<PathBuf>,
     pub(crate) force: bool,
+    pub(crate) default_module_name: Option<String>,
 }
 
 impl Default for Builder {
@@ -20,6 +21,7 @@ impl Default for Builder {
             protoc_args: Default::default(),
             out_dir: None,
             force: false,
+            default_module_name: None,
         }
     }
 }
@@ -44,6 +46,11 @@ impl Builder {
 
     pub fn out_dir(mut self, out_dir: impl AsRef<Path>) -> Self {
         self.out_dir = Some(out_dir.as_ref().to_owned());
+        self
+    }
+
+    pub fn default_module_name(mut self, name: impl AsRef<str>) -> Self {
+        self.default_module_name = Some(name.as_ref().to_string());
         self
     }
 

--- a/grpc-build/src/lib.rs
+++ b/grpc-build/src/lib.rs
@@ -111,7 +111,12 @@ impl Builder {
 
         let file_names = requests
             .iter()
-            .map(|(module, _)| (module.clone(), module.to_file_name_or("_")))
+            .map(|(module, _)| {
+                (
+                    module.clone(),
+                    module.to_file_name_or(self.default_module_name.as_deref().unwrap_or("_")),
+                )
+            })
             .collect::<HashMap<Module, String>>();
 
         let modules = self.prost.generate(requests)?;

--- a/grpc-build/tests/main.rs
+++ b/grpc-build/tests/main.rs
@@ -7,6 +7,7 @@ fn build() {
         .build_server(true)
         .force(true)
         .out_dir("tests/compile_test/protos")
+        .default_module_name("some_default")
         .build("tests/protos/grpc_build")
         .unwrap();
 

--- a/grpc-build/tests/protos/grpc_build/no_package/no_package.proto
+++ b/grpc-build/tests/protos/grpc_build/no_package/no_package.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+// A message with no package defined.
+message NoPackageMessage {
+  string name = 1;
+}


### PR DESCRIPTION
If a proto file doesn't have a package, the generated code would
use `_` as the module name, which doesn't compile.

This change allows setting a default for when no package name
is available.