### PR TITLE
grpc-build 4.2.0

### DIFF
--- a/grpc-build/Cargo.toml
+++ b/grpc-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc-build"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Stefan Adrian Danaita <me@dsa.io>"]
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
Publish has already run, just updating the version in the toml file