### PR TITLE
tonic 0.9 and clap 4

### DIFF
--- a/grpc-build/Cargo.toml
+++ b/grpc-build/Cargo.toml
@@ -26,7 +26,7 @@ prost = "0.11"
 anyhow = "1"
 tonic-build = "0.8"
 prost-build = "0.11"
-structopt = { version ="0.3", features = ["paw"] }
+clap = { version = "4.0.32", features = ["derive"] }
 paw = "1"
 walkdir = "2.3"
 tempfile = "3.3"

--- a/grpc-build/Cargo.toml
+++ b/grpc-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc-build"
-version = "4.4.0"
+version = "5.0.0"
 authors = ["Stefan Adrian Danaita <me@dsa.io>"]
 license = "MIT"
 edition = "2021"
@@ -24,7 +24,7 @@ name = "grpc_build"
 [dependencies]
 prost = "0.11"
 anyhow = "1"
-tonic-build = "0.8"
+tonic-build = "0.9"
 prost-build = "0.11"
 clap = { version = "4.0.32", features = ["derive"] }
 paw = "1"
@@ -34,6 +34,6 @@ prost-types = "0.11"
 fs-err = "2.7"
 
 [dev-dependencies]
-tonic = "0.8"
+tonic = "0.9"
 trybuild = "1.0"
 grpc-build-core = { path = "../grpc-build-core"}

--- a/grpc-build/src/main.rs
+++ b/grpc-build/src/main.rs
@@ -1,28 +1,29 @@
 use anyhow::Result;
+use clap::Parser;
 use grpc_build::Builder;
 
-#[derive(structopt::StructOpt)]
+#[derive(Parser)]
 pub enum Command {
     Build {
-        #[structopt(long)]
+        #[arg(long)]
         in_dir: String,
 
-        #[structopt(long)]
+        #[arg(long)]
         out_dir: String,
 
-        #[structopt(short = "client", long = "build_client")]
+        #[arg(short = 'c', long = "build_client")]
         build_client: bool,
 
-        #[structopt(short = "server", long = "build_server")]
+        #[arg(short = 's', long = "build_server")]
         build_server: bool,
 
-        #[structopt(short = "force", long = "force")]
+        #[arg(short = 'f', long = "force")]
         force: bool,
     },
 }
 
 fn main() -> Result<()> {
-    let command = <Command as paw::ParseArgs>::parse_args()?;
+    let command = Command::try_parse()?;
 
     match command {
         Command::Build {


### PR DESCRIPTION
older versions of clap use `atty` which is now unmaintained and triggers rustsec alerts. The latest versions of clap don't use this anymore