### PR TITLE
support packages and protos in same tree structure

### DIFF
--- a/grpc-build/src/base.rs
+++ b/grpc-build/src/base.rs
@@ -65,7 +65,7 @@ pub fn refactor(output: impl AsRef<Path>) -> Result<()> {
             .collect();
 
         tree.move_paths(output, OsString::new(), PathBuf::new())?;
-        fs_err::write(output.join("mod.rs"), tree.root_mod())?;
+        fs_err::write(output.join("mod.rs"), tree.generate_module())?;
 
         Command::new("rustfmt")
             .arg(output.join("mod.rs"))

--- a/grpc-build/src/base.rs
+++ b/grpc-build/src/base.rs
@@ -65,7 +65,7 @@ pub fn refactor(output: impl AsRef<Path>) -> Result<()> {
             .collect();
 
         tree.move_paths(output, OsString::new(), PathBuf::new())?;
-        fs_err::write(output.join("mod.rs"), tree.to_string())?;
+        fs_err::write(output.join("mod.rs"), tree.root_mod())?;
 
         Command::new("rustfmt")
             .arg(output.join("mod.rs"))

--- a/grpc-build/src/base.rs
+++ b/grpc-build/src/base.rs
@@ -76,3 +76,70 @@ pub fn refactor(output: impl AsRef<Path>) -> Result<()> {
     }
     inner(output.as_ref())
 }
+
+#[cfg(test)]
+mod test {
+    use super::refactor;
+
+    #[test]
+    fn refactor_test_moves_files_to_correct_place() {
+        let files = vec![
+            "root.pak.a1.rs",
+            "root.pak.a2.rs",
+            "root.pak.rs",
+            "root.now.deeply.nested.rs",
+            "root.rs",
+            "other.rs",
+        ];
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir_path = temp_dir.path().to_path_buf();
+        // create files
+        for file in &files {
+            let path = temp_dir_path.join(file);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::File::create(path.clone()).unwrap();
+            // write file name as its content
+            std::fs::write(path.clone(), format!("// {} contents", file)).unwrap();
+        }
+
+        let expected_file_contents = vec![
+            ("root/pak/a1.rs", vec!["// root.pak.a1.rs contents"]),
+            ("root/pak/a2.rs", vec!["// root.pak.a2.rs content"]),
+            (
+                "root/pak.rs",
+                vec!["pub mod a1;", "pub mod a2;", "// root.pak.rs contents"],
+            ),
+            ("root/now.rs", vec!["pub mod deeply;"]),
+            ("root/now/deeply.rs", vec!["pub mod nested;"]),
+            (
+                "root/now/deeply/nested.rs",
+                vec!["// root.now.deeply.nested.rs contents"],
+            ),
+            (
+                "root.rs",
+                vec!["pub mod pak;", "pub mod now;", "// root.rs contents"],
+            ),
+            ("mod.rs", vec!["pub mod other;", "pub mod root;"]),
+            ("other.rs", vec!["// other.rs contents"]),
+        ];
+
+        // Act
+        refactor(&temp_dir_path).unwrap();
+
+        // check if files are moved and contents are correct
+        for (file, contents) in &expected_file_contents {
+            let path = temp_dir_path.join(file);
+            assert!(path.exists());
+            let content = std::fs::read_to_string(path).unwrap();
+            for line in contents {
+                assert!(
+                    content.contains(line),
+                    "{} does not contain {}",
+                    content,
+                    line
+                );
+            }
+        }
+    }
+}

--- a/grpc-build/src/tree.rs
+++ b/grpc-build/src/tree.rs
@@ -39,7 +39,6 @@ impl Tree {
         }
     }
 
-
     /// Generates the module at the root level of the tree
     pub fn generate_module(&self) -> String {
         let mut module = String::from("// Module generated with `grpc_build`\n");
@@ -68,20 +67,13 @@ impl Tree {
             for (k, tree) in &self.0 {
                 tree.move_paths(root, filename.add(k), output.join(k))?;
             }
-
-            eprintln!(
-                "Root is {}, filename {} output {}",
-                root.display(),
-                filename.clone().into_string().unwrap(),
-                output.display()
-            );
+            
             if !filename.is_empty() {
                 self.create_module_file(root, filename, output)?;
             }
         }
         Ok(())
     }
-
 
     fn create_module_file(
         &self,
@@ -94,7 +86,7 @@ impl Tree {
         let final_dest_name = root.join(output.with_extension("rs"));
 
         // Write a temporary file with the module contents
-        let modules = self.generate_module();        
+        let modules = self.generate_module();
         fs_err::write(&dest_tmp_file_name, modules)
             .with_context(|| format!("could not write to file {}", final_dest_name.display()))?;
 

--- a/grpc-build/src/tree.rs
+++ b/grpc-build/src/tree.rs
@@ -47,7 +47,7 @@ impl Tree {
             module.push_str(&format!("pub mod {};\n", k.display()));
         }
 
-        module.push_str("\n");
+        module.push('\n');
         module
     }
 
@@ -136,7 +136,7 @@ fn merge_file_into(from: &PathBuf, to: &PathBuf) -> Result<(), anyhow::Error> {
         )
     })?;
 
-    fs_err::remove_file(&from)
+    fs_err::remove_file(from)
         .with_context(|| format!("could not remove file {}", from.display()))?;
     Ok(())
 }

--- a/grpc-build/src/tree.rs
+++ b/grpc-build/src/tree.rs
@@ -67,7 +67,7 @@ impl Tree {
             for (k, tree) in &self.0 {
                 tree.move_paths(root, filename.add(k), output.join(k))?;
             }
-            
+
             if !filename.is_empty() {
                 self.create_module_file(root, filename, output)?;
             }
@@ -82,7 +82,7 @@ impl Tree {
         output: PathBuf,
     ) -> Result<(), anyhow::Error> {
         let maybe_proto_file_name = root.join(filename.add("rs"));
-        let dest_tmp_file_name = root.join(output.with_extension("tmp.rs"));
+        let dest_tmp_file_name = root.join(output.with_extension("tmp"));
         let final_dest_name = root.join(output.with_extension("rs"));
 
         // Write a temporary file with the module contents


### PR DESCRIPTION
Addresses #39 

Now the module declarations are moved next to each module folder.
When there are protos and packages the protos generated content is appended to the module file.

**Example**:
The following proto packages
```
google.com.networking
google.com
```

Becomes the following structure
```
 mod.rs <----`pub mod google`
 google.rs <--- `pub mod com`
 google/
    com.rs <--- contains `pub mod networking and the google.com protos definitions`
    com/
       networking/
       networking.rs <---- google.com.networking protos
```

This _should_ be a non-breaking change.