### PR TITLE
Support tonic 0.13

### DIFF
--- a/grpc-build-core/Cargo.toml
+++ b/grpc-build-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc-build-core"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Stefan Adrian Danaita <me@dsa.io>"]
 license = "MIT"
 edition = "2021"
@@ -14,6 +14,6 @@ keywords = ["grpc", "tonic", "proto"]
 categories = ["development-tools"]
 
 [dependencies]
-grpc-build-derive = { version = "0.3.0", path = "../grpc-build-derive" }
+grpc-build-derive = { version = "0.4.0", path = "../grpc-build-derive" }
 prost-types = "0.13"
 bytes = "1"

--- a/grpc-build-derive/Cargo.toml
+++ b/grpc-build-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc-build-derive"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Stefan Adrian Danaita <me@dsa.io>"]
 edition = "2021"
 license = "MIT"
@@ -17,5 +17,5 @@ categories = ["development-tools"]
 proc-macro = true
 
 [dependencies]
-syn = "1"
+syn = "2"
 quote = "1"

--- a/grpc-build-derive/src/lib.rs
+++ b/grpc-build-derive/src/lib.rs
@@ -2,7 +2,7 @@
 //! returning the full name of the message including the package namespace.
 
 use proc_macro::TokenStream;
-use syn::{spanned::Spanned, DeriveInput, Lit, MetaNameValue};
+use syn::{spanned::Spanned, DeriveInput, Expr, Lit, MetaNameValue};
 
 #[proc_macro_derive(NamedMessage, attributes(name))]
 pub fn fully_qualified_name(input: TokenStream) -> TokenStream {
@@ -22,11 +22,11 @@ fn impl_fully_qualified_name(ast: &syn::DeriveInput) -> syn::Result<TokenStream>
     };
 
     // search for #[name]
-    let mut name_attrs = ast.attrs.iter().filter(|attr| attr.path.is_ident("name"));
+    let mut name_attrs = ast.attrs.iter().filter(|attr| attr.path().is_ident("name"));
 
     // Let's assume we only have one annotation
     let meta = match name_attrs.next() {
-        Some(attr) => attr.parse_meta()?,
+        Some(attr) => &attr.meta,
         None => return Err(syn::Error::new(ast.span(), "missing #[name] attribute")),
     };
 
@@ -34,11 +34,18 @@ fn impl_fully_qualified_name(ast: &syn::DeriveInput) -> syn::Result<TokenStream>
     //   path    Lit
     let message_name = match meta {
         syn::Meta::NameValue(MetaNameValue {
-            lit: Lit::Str(name),
+            value:
+                Expr::Lit(syn::ExprLit {
+                    lit: Lit::Str(name),
+                    ..
+                }),
             ..
         }) => name,
-        syn::Meta::NameValue(MetaNameValue { lit, .. }) => {
-            return Err(syn::Error::new(lit.span(), "message name MUST be a string"))
+        syn::Meta::NameValue(MetaNameValue { value, .. }) => {
+            return Err(syn::Error::new(
+                value.span(),
+                "message name MUST be a string",
+            ))
         }
         meta => return Err(syn::Error::new(meta.span(), "missing #[name] attribute")),
     };

--- a/grpc-build-derive/src/lib.rs
+++ b/grpc-build-derive/src/lib.rs
@@ -18,8 +18,7 @@ fn impl_fully_qualified_name(ast: &syn::DeriveInput) -> syn::Result<TokenStream>
     // We only annotate structs
     match &ast.data {
         syn::Data::Struct(_) => (),
-        syn::Data::Enum(_) => return Ok(Default::default()),
-        syn::Data::Union(_) => return Ok(Default::default()),
+        syn::Data::Enum(_) | syn::Data::Union(_) => return Ok(TokenStream::default()),
     };
 
     // search for #[name]

--- a/grpc-build/Cargo.toml
+++ b/grpc-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpc-build"
-version = "7.0.0"
+version = "8.0.0"
 authors = ["Stefan Adrian Danaita <me@dsa.io>"]
 license = "MIT"
 edition = "2021"
@@ -24,7 +24,7 @@ name = "grpc_build"
 [dependencies]
 prost = "0.13"
 anyhow = "1"
-tonic-build = "0.12"
+tonic-build = "0.13"
 prost-build = "0.13"
 clap = { version = "4.0.32", features = ["derive"] }
 paw = "1"
@@ -34,6 +34,6 @@ prost-types = "0.13"
 fs-err = "2.7"
 
 [dev-dependencies]
-tonic = "0.12"
+tonic = "0.13"
 trybuild = "1.0"
 grpc-build-core = { path = "../grpc-build-core" }

--- a/grpc-build/src/base.rs
+++ b/grpc-build/src/base.rs
@@ -36,6 +36,7 @@ pub fn prepare_out_dir(out_dir: impl AsRef<Path>) -> Result<()> {
 }
 
 /// Get all the `.proto` files within the provided directory
+#[allow(clippy::filetype_is_file)]
 pub fn get_protos(input: impl AsRef<Path>, follow_links: bool) -> impl Iterator<Item = PathBuf> {
     fn inner(input: &Path, follow_links: bool) -> impl Iterator<Item = PathBuf> {
         // TODO: maybe add this?
@@ -44,9 +45,9 @@ pub fn get_protos(input: impl AsRef<Path>, follow_links: bool) -> impl Iterator<
         WalkDir::new(input)
             .follow_links(follow_links)
             .into_iter()
-            .filter_map(|r| r.map_err(|err| println!("cargo:warning={:?}", err)).ok())
+            .filter_map(|r| r.map_err(|err| println!("cargo:warning={err:?}")).ok())
             .filter(|e| e.file_type().is_file())
-            .filter(|e| e.path().extension().map_or(false, |e| e == "proto"))
+            .filter(|e| e.path().extension().is_some_and(|e| e == "proto"))
             .map(|e| e.path().to_path_buf())
     }
     inner(input.as_ref(), follow_links)
@@ -58,8 +59,8 @@ pub fn get_protos(input: impl AsRef<Path>, follow_links: bool) -> impl Iterator<
 pub fn refactor(output: impl AsRef<Path>) -> Result<()> {
     fn inner(output: &Path) -> Result<()> {
         let tree: crate::tree::Tree = fs_err::read_dir(output)?
-            .filter_map(|r| r.map_err(|err| println!("cargo:warning={:?}", err)).ok())
-            .filter(|e| e.path().extension().map_or(false, |e| e == "rs"))
+            .filter_map(|r| r.map_err(|err| println!("cargo:warning={err:?}")).ok())
+            .filter(|e| e.path().extension().is_some_and(|e| e == "rs"))
             .filter(|e| !e.path().ends_with("mod.rs"))
             .map(|e| e.path())
             .collect();
@@ -100,7 +101,7 @@ mod test {
             std::fs::create_dir_all(path.parent().unwrap()).unwrap();
             std::fs::File::create(path.clone()).unwrap();
             // write file name as its content
-            std::fs::write(path.clone(), format!("// {} contents", file)).unwrap();
+            std::fs::write(path.clone(), format!("// {file} contents")).unwrap();
         }
 
         let expected_file_contents = vec![
@@ -133,12 +134,7 @@ mod test {
             assert!(path.exists());
             let content = std::fs::read_to_string(path).unwrap();
             for line in contents {
-                assert!(
-                    content.contains(line),
-                    "{} does not contain {}",
-                    content,
-                    line
-                );
+                assert!(content.contains(line), "{content} does not contain {line}");
             }
         }
     }

--- a/grpc-build/src/builder.rs
+++ b/grpc-build/src/builder.rs
@@ -32,7 +32,7 @@ impl Default for Builder {
 
 impl Builder {
     pub(crate) fn get_out_dir(&self) -> Result<PathBuf, anyhow::Error> {
-        if let Some(out_dir) = &self.out_dir.clone() {
+        if let Some(out_dir) = &self.out_dir {
             return Ok(out_dir.clone());
         }
 

--- a/grpc-build/src/builder.rs
+++ b/grpc-build/src/builder.rs
@@ -19,8 +19,8 @@ impl Default for Builder {
     fn default() -> Self {
         Self {
             tonic: tonic_build::configure(),
-            prost: Default::default(),
-            protoc_args: Default::default(),
+            prost: prost_build::Config::default(),
+            protoc_args: Vec::default(),
             out_dir: None,
             force: false,
             default_module_name: None,
@@ -32,15 +32,17 @@ impl Default for Builder {
 
 impl Builder {
     pub(crate) fn get_out_dir(&self) -> Result<PathBuf, anyhow::Error> {
-        self.out_dir.clone().map(Ok).unwrap_or_else(|| {
-            std::env::var_os("OUT_DIR")
-                .ok_or_else(|| anyhow::anyhow!("could not determine $OUT_DIR"))
-                .map(Into::into)
-        })
+        if let Some(out_dir) = &self.out_dir.clone() {
+            return Ok(out_dir.clone());
+        }
+
+        std::env::var_os("OUT_DIR")
+            .ok_or_else(|| anyhow::anyhow!("could not determine $OUT_DIR"))
+            .map(Into::into)
     }
 
     pub fn new() -> Self {
-        Default::default()
+        Self::default()
     }
 
     pub fn force(mut self, force: bool) -> Self {

--- a/grpc-build/src/tree.rs
+++ b/grpc-build/src/tree.rs
@@ -150,12 +150,12 @@ impl OsStrExt for OsStr {
     /// Adds `add` to the [`OsStr`], returning a new [`OsString`]. If there already exists data in the string,
     /// this puts a `.` separator inbetween
     fn add(&self, add: impl AsRef<OsStr>) -> OsString {
-        let mut _self = self.to_owned();
-        if !_self.is_empty() {
-            _self.push(".");
+        let mut s = self.to_owned();
+        if !s.is_empty() {
+            s.push(".");
         }
-        _self.push(add);
-        _self
+        s.push(add);
+        s
     }
 }
 
@@ -166,7 +166,7 @@ impl Display for Tree {
             if tree.0.is_empty() {
                 write!(f, ";")?;
             } else {
-                write!(f, "{{{}}}", tree)?;
+                write!(f, "{{{tree}}}")?;
             }
         }
         Ok(())
@@ -267,7 +267,10 @@ pub mod hello;
         .map(PathBuf::from)
         .collect();
 
-        let inner_tree = tree.0.get(&PathBuf::from("grpc_build")).unwrap();
+        let inner_tree = tree
+            .0
+            .get(&PathBuf::from("grpc_build"))
+            .expect("grpc_build module should exist");
         let expected = "// Module generated with `grpc_build`
 pub mod client;
 pub mod request;


### PR DESCRIPTION
This pull request introduces updates across multiple crates in the `grpc-build` ecosystem, including version upgrades, dependency changes, and code improvements for better readability, maintainability, and compatibility. The changes span `Cargo.toml` files, procedural macros, and core library functionality.

### Version and dependency updates:

* [`grpc-build-core/Cargo.toml`](diffhunk://#diff-ece8a86e08ecae43b93f7ebbbd391e842e965148008c8b34decbf20ca79d0e1eL3-R3): Updated crate version to `0.5.0` and bumped `grpc-build-derive` dependency to `0.4.0`. [[1]](diffhunk://#diff-ece8a86e08ecae43b93f7ebbbd391e842e965148008c8b34decbf20ca79d0e1eL3-R3) [[2]](diffhunk://#diff-ece8a86e08ecae43b93f7ebbbd391e842e965148008c8b34decbf20ca79d0e1eL17-R17)
* [`grpc-build-derive/Cargo.toml`](diffhunk://#diff-9b08741d8631047a140b49569e4fa000679a510b5cc1257f936bd0dc1178e144L3-R3): Updated crate version to `0.4.0` and upgraded `syn` dependency to `2`. [[1]](diffhunk://#diff-9b08741d8631047a140b49569e4fa000679a510b5cc1257f936bd0dc1178e144L3-R3) [[2]](diffhunk://#diff-9b08741d8631047a140b49569e4fa000679a510b5cc1257f936bd0dc1178e144L20-R20)
* [`grpc-build/Cargo.toml`](diffhunk://#diff-3d3a97cea3204baf9022b9a455f329e13e0707d0b2e437cabf5f851ddc69eb2fL3-R3): Updated crate version to `8.0.0` and upgraded `tonic-build` and `tonic` dependencies to `0.13`. [[1]](diffhunk://#diff-3d3a97cea3204baf9022b9a455f329e13e0707d0b2e437cabf5f851ddc69eb2fL3-R3) [[2]](diffhunk://#diff-3d3a97cea3204baf9022b9a455f329e13e0707d0b2e437cabf5f851ddc69eb2fL27-R27) [[3]](diffhunk://#diff-3d3a97cea3204baf9022b9a455f329e13e0707d0b2e437cabf5f851ddc69eb2fL37-R37)

### Procedural macro improvements:

* [`grpc-build-derive/src/lib.rs`](diffhunk://#diff-517ccfc0bd3239458524d7e349754ce3863136af4fc889e58de4f3a3d8ccbee6L5-R5): Enhanced handling of `#[name]` attributes in `impl_fully_qualified_name` by using `Expr` for better type safety and updated error messages for clarity. [[1]](diffhunk://#diff-517ccfc0bd3239458524d7e349754ce3863136af4fc889e58de4f3a3d8ccbee6L5-R5) [[2]](diffhunk://#diff-517ccfc0bd3239458524d7e349754ce3863136af4fc889e58de4f3a3d8ccbee6L21-R48)

### Code readability and compatibility improvements:

* [`grpc-build/src/base.rs`](diffhunk://#diff-3a4b886c909468ec12500482d3fd0938e50a7581ce88b20cf351a1391efac5f8L47-R50): Refactored file handling logic to use `is_some_and` for extension checks and improved error formatting with inline variable interpolation. [[1]](diffhunk://#diff-3a4b886c909468ec12500482d3fd0938e50a7581ce88b20cf351a1391efac5f8L47-R50) [[2]](diffhunk://#diff-3a4b886c909468ec12500482d3fd0938e50a7581ce88b20cf351a1391efac5f8L61-R63) [[3]](diffhunk://#diff-3a4b886c909468ec12500482d3fd0938e50a7581ce88b20cf351a1391efac5f8L103-R104) [[4]](diffhunk://#diff-3a4b886c909468ec12500482d3fd0938e50a7581ce88b20cf351a1391efac5f8L136-R137)
* [`grpc-build/src/builder.rs`](diffhunk://#diff-31945aa7efda17c0209db04e669a0d0f8aab913791374b14d52e8b122f7b441bL22-R23): Simplified `get_out_dir` logic and improved default initialization for `prost` and `protoc_args`. [[1]](diffhunk://#diff-31945aa7efda17c0209db04e669a0d0f8aab913791374b14d52e8b122f7b441bL22-R23) [[2]](diffhunk://#diff-31945aa7efda17c0209db04e669a0d0f8aab913791374b14d52e8b122f7b441bL35-R45)
* [`grpc-build/src/tree.rs`](diffhunk://#diff-d257c69383cd9551695efc8ac502eceb2bc1dc3e5195895f030c0ffca863fa0cL153-R158): Improved string manipulation and error handling, including better formatting for `Display` trait implementations. [[1]](diffhunk://#diff-d257c69383cd9551695efc8ac502eceb2bc1dc3e5195895f030c0ffca863fa0cL153-R158) [[2]](diffhunk://#diff-d257c69383cd9551695efc8ac502eceb2bc1dc3e5195895f030c0ffca863fa0cL169-R169) [[3]](diffhunk://#diff-d257c69383cd9551695efc8ac502eceb2bc1dc3e5195895f030c0ffca863fa0cL270-R273)